### PR TITLE
[init] 칸반버킷&칸반카드 Entitiy 최초 작성2

### DIFF
--- a/src/main/java/hanghae/api/coupteambe/domain/entity/kanban/Kanban.java
+++ b/src/main/java/hanghae/api/coupteambe/domain/entity/kanban/Kanban.java
@@ -1,7 +1,0 @@
-package hanghae.api.coupteambe.domain.entity.kanban;
-
-import hanghae.api.coupteambe.domain.entity.baseentity.BaseEntity;
-
-public class Kanban extends BaseEntity {
-
-}

--- a/src/main/java/hanghae/api/coupteambe/domain/entity/kanban/KanbanBucket.java
+++ b/src/main/java/hanghae/api/coupteambe/domain/entity/kanban/KanbanBucket.java
@@ -1,0 +1,50 @@
+package hanghae.api.coupteambe.domain.entity.kanban;
+
+import hanghae.api.coupteambe.domain.entity.baseentity.BaseEntity;
+import hanghae.api.coupteambe.domain.entity.project.Project;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class KanbanBucket extends BaseEntity {
+
+    // 버킷 번호
+    @Id
+    @Column(name = "KBB_ID", nullable = false, updatable = false)
+    private String kbbId;
+
+    // 프로젝트 번호
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PJ_ID", nullable = false, updatable = false)
+    private Project pjId;
+
+    // 보드 번호
+    @Column(name = "KB_ID", nullable = false)
+    private String kbId;
+
+    // 버킷 제목
+    @Column(nullable = false)
+    private String title;
+
+    // 삭제자
+    private String eliminator;
+
+    // 배치순서
+    @Column(nullable = false)
+    private int position;
+
+    @Builder
+    public KanbanBucket(String kbbId, Project pjId, String kbId, String title, String eliminator, int position) {
+        this.kbbId = kbbId;
+        this.pjId = pjId;
+        this.kbId = kbId;
+        this.title = title;
+        this.eliminator = eliminator;
+        this.position = position;
+    }
+}

--- a/src/main/java/hanghae/api/coupteambe/domain/entity/kanban/KanbanCard.java
+++ b/src/main/java/hanghae/api/coupteambe/domain/entity/kanban/KanbanCard.java
@@ -1,0 +1,57 @@
+package hanghae.api.coupteambe.domain.entity.kanban;
+
+import hanghae.api.coupteambe.domain.entity.baseentity.BaseEntity;
+import hanghae.api.coupteambe.domain.entity.project.Project;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class KanbanCard extends BaseEntity {
+
+    // 카드 번호
+    @Id
+    @Column(name = "KBC_ID", updatable = false)
+    private String kbcId;
+
+    // 버킷 번호
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "KBB_ID", updatable = false)
+    private KanbanBucket kanbanBucket;
+
+    // 프로젝트 번호
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PJ_ID", updatable = false)
+    private Project project;
+
+    // 카드 제목
+    @Column(nullable = false)
+    private String title;
+
+    // 본문
+    @Column(nullable = false)
+    private String contents;
+
+    // 삭제자
+    private String eliminator;
+
+    // 배치순서
+    @Column(nullable = false)
+    private int position;
+
+    @Builder
+    public KanbanCard(String kbcId, KanbanBucket kanbanBucket, Project project, String title, String contents,
+                      String eliminator, int position) {
+        this.kbcId = kbcId;
+        this.kanbanBucket = kanbanBucket;
+        this.project = project;
+        this.title = title;
+        this.contents = contents;
+        this.eliminator = eliminator;
+        this.position = position;
+    }
+}


### PR DESCRIPTION
이전 리뷰 반영한 엔티티 작성본입니다.
Kanban -> KanbanBucket + KanbanCard로 Entitiy를 쪼갰고
JPA연관관계 ManyToOne 및 LazyLoading, 각 Entity의 Id지정 및 updatable = false 전략을 적용했습니다.👽