### PR TITLE
[bug] 프로젝트 초대코드 중복 참가 로직 수정완료(Exception 처리) #98

### DIFF
--- a/src/main/java/hanghae/api/coupteambe/controller/ProjectController.java
+++ b/src/main/java/hanghae/api/coupteambe/controller/ProjectController.java
@@ -48,11 +48,8 @@ public class ProjectController {
      */
     @PostMapping("/invite")
     public ResponseEntity<ResResultDto> postInvite(@RequestParam("inviteCode") String inviteCode) {
-
-        projectService.inviteProject(inviteCode);
-
         // 반환값 : 결과 메시지, 상태값(200)
-        return ResponseEntity.ok(new ResResultDto("프로젝트 참가완료"));
+        return projectService.inviteProject(inviteCode);
     }
 
     /**

--- a/src/main/java/hanghae/api/coupteambe/controller/ProjectController.java
+++ b/src/main/java/hanghae/api/coupteambe/controller/ProjectController.java
@@ -48,8 +48,11 @@ public class ProjectController {
      */
     @PostMapping("/invite")
     public ResponseEntity<ResResultDto> postInvite(@RequestParam("inviteCode") String inviteCode) {
+
+        projectService.inviteProject(inviteCode);
+
         // 반환값 : 결과 메시지, 상태값(200)
-        return projectService.inviteProject(inviteCode);
+        return ResponseEntity.ok(new ResResultDto("프로젝트 참가완료"));
     }
 
     /**

--- a/src/main/java/hanghae/api/coupteambe/domain/entity/project/ProjectMember.java
+++ b/src/main/java/hanghae/api/coupteambe/domain/entity/project/ProjectMember.java
@@ -31,7 +31,7 @@ public class ProjectMember extends BaseTimeEntity {
     @JoinColumn(name = "pjId")
     private Project project;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mbId")
     private Member member;
 

--- a/src/main/java/hanghae/api/coupteambe/domain/repository/project/ProjectMemberRepository.java
+++ b/src/main/java/hanghae/api/coupteambe/domain/repository/project/ProjectMemberRepository.java
@@ -1,10 +1,11 @@
 package hanghae.api.coupteambe.domain.repository.project;
 
+import hanghae.api.coupteambe.domain.entity.member.Member;
 import hanghae.api.coupteambe.domain.entity.project.ProjectMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface ProjectMemberRepository extends JpaRepository<ProjectMember, UUID>, ProjectMemberRepositoryCustom {
-
+    boolean existsByMember(Member member);
 }

--- a/src/main/java/hanghae/api/coupteambe/service/ProjectService.java
+++ b/src/main/java/hanghae/api/coupteambe/service/ProjectService.java
@@ -1,6 +1,5 @@
 package hanghae.api.coupteambe.service;
 
-import hanghae.api.coupteambe.domain.dto.ResResultDto;
 import hanghae.api.coupteambe.domain.dto.project.CreateProjectDto;
 import hanghae.api.coupteambe.domain.dto.project.ReqProjectInfoDto;
 import hanghae.api.coupteambe.domain.dto.project.ResProjectInfoDto;
@@ -14,7 +13,6 @@ import hanghae.api.coupteambe.domain.repository.project.ProjectRepositoryImpl;
 import hanghae.api.coupteambe.util.exception.ErrorCode;
 import hanghae.api.coupteambe.util.exception.RequestException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -70,7 +68,7 @@ public class ProjectService {
     /**
      * M5-3 프로젝트 초대코드로 참가
      */
-    public ResponseEntity<ResResultDto> inviteProject(String inviteCode) {
+    public void inviteProject(String inviteCode) {
 
         // 1. 초대 코드를 가진 프로젝트를 조회한다.
         Optional<Project> optionalProject = projectRepository.findByInviteCode(inviteCode);
@@ -91,12 +89,11 @@ public class ProjectService {
             ProjectMember projectMember = new ProjectMember(member, project);
             // 3-2. 프로젝트 저장
             projectMemberRepository.save(projectMember);
-            // 반환값 : 결과 메시지(참가 성공), 상태값(200)
-            return ResponseEntity.ok(new ResResultDto("프로젝트 참가완료"));
+        } else {
+            // 3-3. 프로젝트에 이미 참가한 경우, 예외처리
+            throw new RequestException(ErrorCode.PROJECT_MEMBER_DUPLICATION_409);
         }
 
-        // 반환값 : 결과 메시지(이미 참가한 유저), 상태값(200)
-        return ResponseEntity.ok(new ResResultDto("프로젝트에 이미 참가한 유저입니다."));
     }
 
     /**

--- a/src/main/java/hanghae/api/coupteambe/util/exception/ErrorCode.java
+++ b/src/main/java/hanghae/api/coupteambe/util/exception/ErrorCode.java
@@ -46,6 +46,9 @@ public enum ErrorCode {
     PROJECT_NOT_FOUND_404(HttpStatus.NOT_FOUND, "요청한 프로젝트 ID가 없습니다."),
     PROJECT_DUPLICATION_409(HttpStatus.CONFLICT, "이미 등록된 프로젝트 ID 입니다."),
 
+    // ProjectMember 관련
+    PROJECT_MEMBER_DUPLICATION_409(HttpStatus.CONFLICT, "이미 프로젝트에 참가되어 있는 회원입니다."),
+
     // Kanban 관련
     KANBAN_BUCKET_NOT_FOUND_404(HttpStatus.NOT_FOUND, "요청한 칸반보드 ID가 없습니다."),
     KANBAN_CARD_NOT_FOUND_404(HttpStatus.NOT_FOUND, "요청한 칸반카드 ID가 없습니다."),


### PR DESCRIPTION
컨트롤러는 기존과 같이 service호출 및 상태값200, 정상 메시지 반환만 하도록 변경하고
서비스 단에서 중복 참가의 경우, Exception으로 돌려서 상태값을 ErrorCode 409 예외처리 하도록 수정했습니다.