### PR TITLE
[fix] 공지사항 조회 버그 수정 및 CUD 권한 수정 #168

### DIFF
--- a/src/main/java/hanghae/api/coupteambe/controller/NoticeController.java
+++ b/src/main/java/hanghae/api/coupteambe/controller/NoticeController.java
@@ -55,8 +55,8 @@ public class NoticeController {
      * O1-5. 공지사항 글 삭제
      */
     @DeleteMapping("/")
-    public ResponseEntity<ResResultDto> deleteNotice(@RequestParam("noticeId") String noticeId) {
-        noticeService.deleteNotice(noticeId);
+    public ResponseEntity<ResResultDto> deleteNotice(@RequestBody NoticeInfoDto noticeInfoDto) {
+        noticeService.deleteNotice(noticeInfoDto);
         return ResponseEntity.ok(new ResResultDto("공지사항 삭제 성공"));
     }
 

--- a/src/main/java/hanghae/api/coupteambe/domain/entity/project/Project.java
+++ b/src/main/java/hanghae/api/coupteambe/domain/entity/project/Project.java
@@ -31,7 +31,7 @@ public class Project extends BaseEntity {
     @Column(nullable = false, length = 20)
     private String title;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false)
     private String summary;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/hanghae/api/coupteambe/domain/repository/notice/NoticeRepositoryCustom.java
+++ b/src/main/java/hanghae/api/coupteambe/domain/repository/notice/NoticeRepositoryCustom.java
@@ -8,5 +8,5 @@ import java.util.UUID;
 public interface NoticeRepositoryCustom {
 
     // 프로젝트 내 공지사항 전체 조회
-    List<NoticeInfoDto> findNoticesFromProjectByProjectMbId_DSL(UUID pjMbId);
+    List<NoticeInfoDto> findAllNoticeByPjId_DSL(UUID pjId);
 }

--- a/src/main/java/hanghae/api/coupteambe/domain/repository/notice/NoticeRepositoryImpl.java
+++ b/src/main/java/hanghae/api/coupteambe/domain/repository/notice/NoticeRepositoryImpl.java
@@ -16,7 +16,7 @@ public class NoticeRepositoryImpl implements NoticeRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<NoticeInfoDto> findNoticesFromProjectByProjectMbId_DSL(UUID pjMbId) {
+    public List<NoticeInfoDto> findAllNoticeByPjId_DSL(UUID pjId) {
         QProjectMember projectMember = QProjectMember.projectMember;
         QNotice notice = QNotice.notice;
 
@@ -32,7 +32,8 @@ public class NoticeRepositoryImpl implements NoticeRepositoryCustom {
                 .leftJoin(projectMember)
                 .on(projectMember.id.eq(notice.projectMember.id))
                 .fetchJoin()
-                .where(notice.projectMember.id.eq(pjMbId))
+                .where(projectMember.project.id.eq(pjId))
                 .distinct().fetch();
     }
+
 }

--- a/src/main/java/hanghae/api/coupteambe/service/NoticeService.java
+++ b/src/main/java/hanghae/api/coupteambe/service/NoticeService.java
@@ -13,11 +13,11 @@ import hanghae.api.coupteambe.enumerate.ProjectRole;
 import hanghae.api.coupteambe.util.exception.ErrorCode;
 import hanghae.api.coupteambe.util.exception.RequestException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static hanghae.api.coupteambe.util.SecurityUtil.getCurrentUsername;
@@ -36,35 +36,41 @@ public class NoticeService {
      */
     @Transactional
     public void createNotice(NoticeInfoDto noticeInfoDto) {
-        // 1-1. 일반 유저 접근 시, 예외 처리
-//        if(!projectMember.getRole().equals(ProjectRole.ADMIN)) {
-//            throw new RequestException(ErrorCode.NO_PERMISSION_TO_WRITE_NOTICE);
-//        }
-
-//        // 2. 공지사항을 업로드할 대상 프로젝트가 존재하는지 확인
-//        UUID mbId = projectMember.getMember().getId();
-//        UUID pjId = noticeInfoDto.getPjId();
-
+        // 1. 로그인 한 유저의 로그인 ID 추출
         String loginId = getCurrentUsername()
+                // 1-1. 로그인 안된 경우 예외처리
                 .orElseThrow(() -> new RequestException(ErrorCode.COMMON_BAD_REQUEST_400));
 
+        // 2. DB 에 해당 유저가 존재하는지 확인
         Member member = memberRepository.findByLoginId(loginId)
+                // 2-1. 존재하지 않는 경우 예외처리
                 .orElseThrow(() -> new RequestException(ErrorCode.MEMBER_LOGINID_NOT_FOUND_404));
-        UUID mbId = member.getId();
-        UUID pjId = noticeInfoDto.getPjId();
 
-        ProjectMember projectMember = projectMemberRepository.findProjectMemberFromProjectMemberByPjIdAndMbId_DSL(pjId, mbId);
+        // 3. 프로젝트 조회
+        Project project = projectRepository.findById(noticeInfoDto.getPjId())
+                // 3-1. 존재하지 않는 경우 예외처리
+                .orElseThrow(() -> new RequestException(ErrorCode.PROJECT_NOT_FOUND_404));
 
-        // 3. 공지사항 객체 생성
-        Notice notice = Notice.builder()
-                .title(noticeInfoDto.getTitle())
-                .contents(noticeInfoDto.getContents())
-                .projectMember(projectMember)
-                .build();
-
-        // 4. 공지사항 저장
-        noticeRepository.save(notice);
-
+        // 4. 유저 권한 조회
+        Optional<ProjectMember> projectMember = projectMemberRepository.findByMemberIdAndProjectId(member.getId(), project.getId());
+        if (projectMember.isPresent()) {
+            // 4-1. 관리자인 경우에만 공지 작성 가능
+            if (projectMember.get().getRole().equals(ProjectRole.ADMIN)) {
+                // 5. 공지사항 객체 생성
+                Notice notice = Notice.builder()
+                        .title(noticeInfoDto.getTitle())
+                        .contents(noticeInfoDto.getContents())
+                        .projectMember(projectMember.get())
+                        .build();
+                // 6. 공지사항 저장
+                noticeRepository.save(notice);
+            } else {
+                // 4-2. 관리자가 아닌 경우, 예외처리
+                throw new RequestException(ErrorCode.NO_PERMISSION_TO_WRITE_NOTICE_400);
+            }
+        } else {
+            throw new RequestException(ErrorCode.COMMON_BAD_REQUEST_400);
+        }
     }
 
     /**
@@ -72,14 +78,11 @@ public class NoticeService {
      */
     public List<NoticeInfoDto> getAllNotices(String pjId) {
         // 1. 프로젝트가 존재하는지 조회
-        Project project = projectRepository.findById(UUID.fromString(pjId))
-                .orElseThrow(() -> new RequestException(ErrorCode.PROJECT_NOT_FOUND_404));
-
-        ProjectMember projectMember = projectMemberRepository.findTop1ByProjectId(UUID.fromString(pjId))
+        projectRepository.findById(UUID.fromString(pjId))
                 .orElseThrow(() -> new RequestException(ErrorCode.PROJECT_NOT_FOUND_404));
 
         // 2. 공지사항 전체 조회
-        return noticeRepository.findNoticesFromProjectByProjectMbId_DSL(projectMember.getId());
+        return noticeRepository.findAllNoticeByPjId_DSL(UUID.fromString(pjId));
     }
 
     /**
@@ -97,21 +100,40 @@ public class NoticeService {
      */
     @Transactional
     public void modifyNotice(NoticeInfoDto noticeInfoDto) {
-        // 1. 유저 권한 조회
-        ProjectMember projectMember = searchUserInfo();
+        // 1. 로그인 한 유저의 로그인 ID 추출
+        String loginId = getCurrentUsername()
+                // 1-1. 로그인 안된 경우 예외처리
+                .orElseThrow(() -> new RequestException(ErrorCode.COMMON_BAD_REQUEST_400));
 
-        // 1-1. 일반 유저 접근 시, 예외 처리
-        if(!projectMember.getRole().equals(ProjectRole.ADMIN)) {
-            throw new RequestException(ErrorCode.NO_PERMISSION_TO_MODIFY_NOTICE);
+        // 2. DB 에 해당 유저가 존재하는지 확인
+        Member member = memberRepository.findByLoginId(loginId)
+                // 2-1. 존재하지 않는 경우 예외처리
+                .orElseThrow(() -> new RequestException(ErrorCode.MEMBER_LOGINID_NOT_FOUND_404));
+
+        // 3. 프로젝트 조회
+        Project project = projectRepository.findById(noticeInfoDto.getPjId())
+                // 3-1. 존재하지 않는 경우 예외처리
+                .orElseThrow(() -> new RequestException(ErrorCode.PROJECT_NOT_FOUND_404));
+
+        // 4. 유저 권한 조회
+        Optional<ProjectMember> projectMember = projectMemberRepository.findByMemberIdAndProjectId(member.getId(), project.getId());
+        if (projectMember.isPresent()) {
+            // 4-1. 관리자인 경우에만 공지 작성 가능
+            if (projectMember.get().getRole().equals(ProjectRole.ADMIN)) {
+                // 2. 해당 공지사항이 존재하는지 조회
+                UUID noticeId = noticeInfoDto.getNoticeId();
+                Notice notice = noticeRepository.findById(noticeId)
+                        .orElseThrow(() -> new RequestException(ErrorCode.NOTICE_NOT_FOUND_404));
+
+                // 3. 공지사항 수정
+                notice.updateNotice(noticeInfoDto);
+            } else {
+                // 4-2. 관리자가 아닌 경우, 예외처리
+                throw new RequestException(ErrorCode.NO_PERMISSION_TO_WRITE_NOTICE_400);
+            }
+        } else {
+            throw new RequestException(ErrorCode.COMMON_BAD_REQUEST_400);
         }
-
-        // 2. 해당 공지사항이 존재하는지 조회
-        UUID noticeId = noticeInfoDto.getNoticeId();
-        Notice notice = noticeRepository.findById(noticeId)
-                .orElseThrow(() -> new RequestException(ErrorCode.NOTICE_NOT_FOUND_404));
-
-        // 3. 공지사항 수정
-        notice.updateNotice(noticeInfoDto);
     }
 
     /**
@@ -119,29 +141,40 @@ public class NoticeService {
      */
     @Transactional
     public void deleteNotice(String noticeId) {
-        // 1. 유저 권한 조회
-        ProjectMember projectMember = searchUserInfo();
 
-        // 1-1. 일반 유저 접근 시, 예외 처리
-        if(!projectMember.getRole().equals(ProjectRole.ADMIN)) {
-            throw new RequestException(ErrorCode.NO_PERMISSION_TO_DELETE_NOTICE);
-        }
-        
-        // 2. 공지사항 글 삭제
-        noticeRepository.deleteById(UUID.fromString(noticeId));
-    }
+        // 1. 로그인 한 유저의 로그인 ID 추출
+        String loginId = getCurrentUsername()
+                // 1-1. 로그인 안된 경우 예외처리
+                .orElseThrow(() -> new RequestException(ErrorCode.COMMON_BAD_REQUEST_400));
 
-    /**
-     * 유저 정보 조회
-     */
-    private ProjectMember searchUserInfo() {
-        // 1. 로그인한 유저 아이디 추출
-        String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
-        // 2. 유저가 Member DB 에 존재하는지 조회
+        // 2. DB 에 해당 유저가 존재하는지 확인
         Member member = memberRepository.findByLoginId(loginId)
+                // 2-1. 존재하지 않는 경우 예외처리
                 .orElseThrow(() -> new RequestException(ErrorCode.MEMBER_LOGINID_NOT_FOUND_404));
-        // 3. 유저가 ProjectMember DB 에 존재하는지 조회
-        return projectMemberRepository.findByMember(member)
-                .orElseThrow(() -> new RequestException(ErrorCode.MEMBER_LOGINID_NOT_FOUND_404));
+
+        //TODO 삭제하려는 유저의 해당 프로젝트 권한(관리자 or 일반유저)을 확인하기 위해서는
+        // 프로젝트 ID(pjId) 를 Request 에서 파라매터로 받아야 함.
+
+//        // 3. 프로젝트 조회
+//        Project project = projectRepository.findById(프로젝트ID)
+//                // 3-1. 존재하지 않는 경우 예외처리
+//                .orElseThrow(() -> new RequestException(ErrorCode.PROJECT_NOT_FOUND_404));
+//
+//        // 4. 유저 권한 조회
+//        Optional<ProjectMember> projectMember = projectMemberRepository.findByMemberIdAndProjectId(member.getId(), project.getId());
+//        if (projectMember.isPresent()) {
+//            // 4-1. 관리자인 경우에만 공지 삭제 가능
+//            if (projectMember.get().getRole().equals(ProjectRole.ADMIN)) {
+//                noticeRepository.deleteById(UUID.fromString(noticeId));
+//            } else {
+//                // 4-2. 관리자가 아닌 경우, 예외처리
+//                throw new RequestException(ErrorCode.NO_PERMISSION_TO_WRITE_NOTICE_400);
+//            }
+//        } else {
+//            throw new RequestException(ErrorCode.COMMON_BAD_REQUEST_400);
+//        }
+
+        // 공지사항 삭제
+        noticeRepository.deleteById(UUID.fromString(noticeId));
     }
 }

--- a/src/main/java/hanghae/api/coupteambe/util/exception/ErrorCode.java
+++ b/src/main/java/hanghae/api/coupteambe/util/exception/ErrorCode.java
@@ -68,9 +68,9 @@ public enum ErrorCode {
     NOTICE_NOT_FOUND_404(HttpStatus.NOT_FOUND, "해당 공지사항이 존재하지 않습니다."),
 
     // Role 관련
-    NO_PERMISSION_TO_WRITE_NOTICE(HttpStatus.FORBIDDEN, "공지 사항 작성 권한이 없습니다."),
-    NO_PERMISSION_TO_MODIFY_NOTICE(HttpStatus.FORBIDDEN, "공지 사항 수정 권한이 없습니다."),
-    NO_PERMISSION_TO_DELETE_NOTICE(HttpStatus.FORBIDDEN, "공지 사항 삭제 권한이 없습니다."),
+    NO_PERMISSION_TO_WRITE_NOTICE_400(HttpStatus.FORBIDDEN, "공지 사항 작성 권한이 없습니다."),
+    NO_PERMISSION_TO_MODIFY_NOTICE_400(HttpStatus.FORBIDDEN, "공지 사항 수정 권한이 없습니다."),
+    NO_PERMISSION_TO_DELETE_NOTICE_400(HttpStatus.FORBIDDEN, "공지 사항 삭제 권한이 없습니다."),
 
 
     /**


### PR DESCRIPTION
[fix] 공지사항 조회 버그 수정 및 CUD 권한 수정 #168
1. 새 공지 생성 시, Admin 권한 조회
2. 공지 삭제 시, request 값 변경
 [기존] noticeId, [변경] noticeId 와 pjId가 포함된 NoticeInfoDto를 parameter로 넘김