### PR TITLE
[fix] Google 로그인 refreshToken null 버그 수정 #196

### DIFF
--- a/src/main/java/hanghae/api/coupteambe/service/AuthGoogleService.java
+++ b/src/main/java/hanghae/api/coupteambe/service/AuthGoogleService.java
@@ -69,9 +69,7 @@ public class AuthGoogleService {
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode responseToken = objectMapper.readTree(responseBody);
         String accessToken = responseToken.get("access_token").asText();
-        String refreshToken = responseToken.get("refresh_token").asText();
         log.debug("access token : " + accessToken);
-        log.debug("refresh token : " + refreshToken);
 
         return accessToken;
     }


### PR DESCRIPTION
초회 로그인 시 access토큰 및 refresh토큰을 구글에서 발급하기 때문에 로그인 문제 없음
하지만 다른 소셜 로그인과 달리 2회차 이상 로그인 시도 시,
기존에 발급된 refresh토큰이 만료되지 않는 한, refresh토큰은 구글에서 발급해주지 않음.

그러나 우리 로직에서 refresh token 은 굳이 안 가져와도 되기에 라인 삭제함
1. jwt token쓰기 때문에
2. 구글에서 발급해주는 access토큰은 사용자 정보 받아오는 용도로만 사용하기때문(refresh안씀)

[참고사이트]
https://doogle.link/%EA%B5%AC%EA%B8%80-%EC%95%84%EC%9D%B4%EB%94%94%EB%A1%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84%EC%A4%91-%EB%A6%AC%ED%94%84%EB%A0%88%EC%8B%9C-%ED%86%A0%ED%81%B0refresh-token-%EC%9D%B4/