### PR TITLE
[fix] 추방당한 멤버 초대코드 입력시 필터링 로직 추가 #221

### DIFF
--- a/src/main/java/hanghae/api/coupteambe/util/exception/ErrorCode.java
+++ b/src/main/java/hanghae/api/coupteambe/util/exception/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
 
     // ProjectMember 관련
     PROJECT_MEMBER_DUPLICATION_409(HttpStatus.CONFLICT, "이미 프로젝트에 참가되어 있는 회원입니다."),
+    DENIED_TO_JOIN_PROJECT_409(HttpStatus.FORBIDDEN, "프로젝트 참가가 거부된 회원입니다."),
 
     // Kanban 관련
     KANBAN_BUCKET_NOT_FOUND_404(HttpStatus.NOT_FOUND, "요청한 칸반보드 ID가 없습니다."),


### PR DESCRIPTION
이미 참가한 유저가 입장 불가한 메시지와
프로젝트에서 나가거나 추방 당한 멤버가 입장 불가한 메시지를
구분하기 위한 로직을 추가함